### PR TITLE
Adding ability to lookup on domain, url, email, and hash (MD5 and SHA)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![image](https://img.shields.io/badge/status-beta-green.svg)
 
-Polarity's ThreatStream integration gives users access to automated IPv4 lookups within Anomali's ThreatStream platform..
+Polarity's ThreatStream integration gives users access to automated IPv4, domain, URL, email, and hash (MD5 and SHA) lookups within Anomali's ThreatStream platform..
 
 To learn more about Anomali ThreatStream please see their official website at [https://www.anomali.com/platform/threatstream](https://www.anomali.com/platform/threatstream)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![image](https://img.shields.io/badge/status-beta-green.svg)
 
-Polarity's ThreatStream integration gives users access to automated IPv4, domain, URL, email, and hash (MD5 and SHA) lookups within Anomali's ThreatStream platform..
+Polarity's ThreatStream integration gives users access to automated IPv4, domain, URL, email, and hash (MD5, SHA1, and SHA256) lookups within Anomali's ThreatStream platform..
 
 To learn more about Anomali ThreatStream please see their official website at [https://www.anomali.com/platform/threatstream](https://www.anomali.com/platform/threatstream)
 

--- a/Test Data
+++ b/Test Data
@@ -1,0 +1,32 @@
+    # These are real malicous sites, ips, emails, etc, don't attempt to access them.
+
+    # Domains
+    netkeycompany.com
+    makemoneypearse.pw
+    http://fivethreemotherfatherdogcat.pw
+    www.rootplacecomndeelotoswelcome.pw
+    https://www.martuswalmart.pw
+
+    # URLs
+    http://sevenweeksdays.co.za/docss/file/files/db/file.dropbox/
+    http://www.fgconsultoria.net/advance/information-account/BOA/home/confirm.php
+    http://www.sherwoodcommunityclassifieds.com/wp-content/50242/step2.php
+
+    # IPs
+    43.239.221.51
+    45.74.19.139
+    116.255.195.133
+
+    # Emails
+    admin@villargo.com
+    amhartsell0716@limestone.edu
+    brown3431@sbcglobal.net
+    emailverificationsecurity@protection.com
+    enoreply@support-team.com
+
+    # Hashes
+    e889544aff85ffaf8b0d0da705105dee7c97fe26
+    e28dca64178f43907eda9f04823066769ab233bc1b0719aab9d7c90b7451dd7a
+    0aa9719e0b8474a88b90976a5eb3ee55
+    e373b7f49e07d0c6176565357aedbe61e2d39306
+    5a58e4a4910fbbb8092af231cba2e7cf9f9c0acf6ec88ccb7e0566fcf7b03415

--- a/config/config.js
+++ b/config/config.js
@@ -23,7 +23,7 @@ module.exports = {
      * @optional
      */
     description: "Anomali ThreatStream is a Threat Intelligence Platform allowing organizations to access all intelligence feeds and integrate them seamlessly with internal security and IT systems.",
-    entityTypes: ['IPv4', 'domain', 'email', 'hash', 'url'],
+    entityTypes: ['IPv4', 'domain', 'email', 'MD5', 'SHA1', 'SHA256', 'url'],
     /**
      * An array of style files (css or less) that will be included for your integration. Any styles specified in
      * the below files can be used in your custom template.

--- a/config/config.js
+++ b/config/config.js
@@ -23,7 +23,7 @@ module.exports = {
      * @optional
      */
     description: "Anomali ThreatStream is a Threat Intelligence Platform allowing organizations to access all intelligence feeds and integrate them seamlessly with internal security and IT systems.",
-    entityTypes: ['IPv4'],
+    entityTypes: ['IPv4', 'domain', 'email', 'hash', 'url'],
     /**
      * An array of style files (css or less) that will be included for your integration. Any styles specified in
      * the below files can be used in your custom template.

--- a/integration.js
+++ b/integration.js
@@ -35,8 +35,6 @@ function createEntityGroups(entities, options, cb) {
 
         if ((entity.isPrivateIP || IGNORED_IPS.has(entity.value)) && options.ignorePrivateIps) {
             return;
-        } else if (isIgnorableHash(entity)) {
-            return;
         } else {
             entityGroup.push('value="' + entity.value + '"');
             entityLookup[entity.value.toLowerCase()] = entity;
@@ -49,15 +47,6 @@ function createEntityGroups(entities, options, cb) {
     }
 
     _doLookup(entityGroups, entityLookup, options, cb);
-}
-
-// Threatstream API only supports MD5 and SHA hashes currently.
-function isIgnorableHash(entity) {
-    return entity.isHash 
-        && !entity.isMD5 
-        && !entity.isSHA1 
-        && !entity.isSHA256 
-        && !entity.isSHA512;
 }
 
 /**


### PR DESCRIPTION
This PR adds the ability to look up domains, URLs, emails, and hashes identified by Polarity in the ThreatStream platform.  Some points to note:

1) I accomplished adding the additional lookup types by `OR`'ing the types are are passed into the API query.  I ran some very simple tests in postman and there appears to be a slight degradation in query performance the more types are added to the query, about 200-400ms.  I was not sure how performance critical this section of the code was.  If this is something worth pursuing, I believe that parallelizing the queries would allow us to maintain the original performance of the integration, although I would need to do some refactoring of the code.

2) I wasn't sure what type of hashes Polarity will give the integration.  The entity only lists MD5, SHA1, SHA256, and SHA512 as possibilities, but I wasn't sure if other options would make it through or are planned to be added soon.  Because ThreatStream only allows MD5 and SHA (documentation isn't clear on what kinds of SHA hashes are allowed), I implemented a (hopefully) forward-compatible check on the hash that is sent in to the integration (line 55 integration.js).

3) If the tags array in the indicator groups that are being sent to the client are null then the entity will not display at all.  In order to fix this I added logic to set null or undefined tags to empty arrays, which appears to resolve the issue (line 91 integration.js)

4) Domains are a little bit finicky, the presence or absence of `www` seems to affect whether a result is returned or not.  I realize that this might be valid in some cases, but I wasn't sure if I should look into "sanitizing" the data that comes in, most likely by removing any leading `www` on the domains.

Please let me know any thoughts about the above or other suggestions.

There is a test data file included in this PR that should allow testing all the new features.