### PR TITLE
Fix hash lookups

### DIFF
--- a/integration.js
+++ b/integration.js
@@ -34,6 +34,7 @@ async function createEntityGroups(entities, options, cb) {
     try {
       await anomali.cachePreferredTags(options);
     } catch (err) {
+      Logger.error({err}, 'Error fetching tag');
       return cb(err);
     }
   }
@@ -60,6 +61,8 @@ async function createEntityGroups(entities, options, cb) {
       entityLookup[entity.value.toLowerCase()] = entity;
     }
   });
+  
+  Logger.trace({ entityGroups: entityGroups }, 'Entity Groups');
 
   // grab any "trailing" entities
   if (entityGroup.length > 0) {
@@ -227,6 +230,8 @@ function _lookupEntity(entitiesArray, entityLookup, types, options, done) {
         done(err);
         return;
       }
+      
+      Logger.trace({body}, 'Result of lookup');
 
       // body.objects is an array of objects where each object is an indicator
       // there can be more than one indicator object for a single indicator value
@@ -258,7 +263,13 @@ function _getType(entityType) {
     case 'url':
       return 'type=url';
     case 'hash':
-      return 'type=md5';
+      return 'type=hash';
+    case 'MD5':
+      return 'type=hash';
+    case 'SHA1':
+      return 'type=hash';
+    case 'SHA256':
+      return 'type=hash';
     case 'email':
       return 'type=email';
     default:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "AnomaliThreatStream",
-  "version": "3.2.10",
+  "version": "3.2.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -26,9 +26,9 @@
       }
     },
     "@postman/tunnel-agent": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@postman/tunnel-agent/-/tunnel-agent-0.6.3.tgz",
-      "integrity": "sha512-k57fzmAZ2PJGxfOA4SGR05ejorHbVAa/84Hxh/2nAztjNXc4ZjOm9NUIk6/Z6LCrBvJZqjRZbN8e/nROVUPVdg==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@postman/tunnel-agent/-/tunnel-agent-0.6.4.tgz",
+      "integrity": "sha512-CJJlq8V7rNKhAw4sBfjixKpJW00SHqebqNUQKxMoepgeWZIbdPcD+rguRcivGhS4N12PymDcKgUgSD4rVC+RjQ==",
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -58,9 +58,9 @@
       "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw=="
     },
     "async": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
-      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -73,9 +73,9 @@
       "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA=="
     },
     "aws4": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.0.tgz",
-      "integrity": "sha512-3AungXC4I8kKsS9PuS4JH2nc+0bVY/mjgrephHTIi8fpEeGsTHBUJeosp0Wc1myYMElmD0B3Oc4XL/HVJ4PV2g=="
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw=="
     },
     "base64-js": {
       "version": "1.5.1",
@@ -270,13 +270,13 @@
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
     },
     "postman-request": {
-      "version": "2.88.1-postman.34",
-      "resolved": "https://registry.npmjs.org/postman-request/-/postman-request-2.88.1-postman.34.tgz",
-      "integrity": "sha512-GkolJ4cIzgamcwHRDkeZc/taFWO1u2HuGNML47K9ZAsFH2LdEkS5Yy8QanpzhjydzV3WWthl9v60J8E7SjKodQ==",
+      "version": "2.88.1-postman.40",
+      "resolved": "https://registry.npmjs.org/postman-request/-/postman-request-2.88.1-postman.40.tgz",
+      "integrity": "sha512-uE4AiIqhjtHKp4pj9ei7fkdfNXEX9IqDBlK1plGAQne6y79UUlrTdtYLhwXoO0AMOvqyl9Ar+BU6Eo6P/MPgfg==",
       "requires": {
         "@postman/form-data": "~3.1.1",
         "@postman/tough-cookie": "~4.1.3-postman.1",
-        "@postman/tunnel-agent": "^0.6.3",
+        "@postman/tunnel-agent": "^0.6.4",
         "aws-sign2": "~0.7.0",
         "aws4": "^1.12.0",
         "brotli": "^1.3.3",
@@ -299,9 +299,12 @@
       }
     },
     "psl": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "requires": {
+        "punycode": "^2.3.1"
+      }
     },
     "punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "AnomaliThreatStream",
-  "version": "3.2.10",
+  "version": "3.2.11",
   "main": "./integration.js",
   "private": true,
   "dependencies": {
-    "postman-request": "^2.88.1-postman.34",
+    "postman-request": "^2.88.1-postman.40",
     "lodash": "^4.17.21",
-    "async": "^3.2.5"
+    "async": "^3.2.6"
   }
 }

--- a/templates/threatstream-block.hbs
+++ b/templates/threatstream-block.hbs
@@ -13,7 +13,7 @@
     </li>
 </ul>
 {{#if (eq activeTab "details")}}
-    {{#each (take maxSourcesInBlock enrichedDetails) as |item index|}}
+    {{#each (limit enrichedDetails maxSourcesInBlock) as |item index|}}
         <div class="item">
             {{#if item.__showUpdateModal}}
                 <div class="update-modal">
@@ -59,8 +59,25 @@
             </div>
             <div>
                 <span class="p-key">Type: </span>
+              {{#if (eq item.type "md5")}}
+                <span class="p-value">
+                  Hash
+                  {{#if (eq item.itype "mal_md5")}}
+                    (Malware File Hash)
+                  {{else}}
+                    ({{item.itype}})  
+                  {{/if}}                  
+                </span>
+              {{else}}
                 <span class="p-value">{{item.type}} ({{item.itype}})</span>
+              {{/if}}                
             </div>
+          {{#if item.subtype}}
+            <div>
+              <span class="p-key">Sub Type: </span>
+              <span class="p-value">{{item.subtype}}</span>
+            </div>
+          {{/if}}
             <div>
                 <span class="p-key">Threat Score: </span>
                 <span class="p-value">{{item.threatscore}}</span>
@@ -106,7 +123,7 @@
                 {{fa-icon "tags" fixedWidth=true}} Tags<span class="ml-1">{{#if item.__deletingTag}}{{fa-icon "spinner-third" spin=true fixedWidth=true}}{{/if}}</span>
             </h1>
             <div class="tag-container">
-                {{#each (take maxTagsInBlock item.tags) as |tag tagIndex|}}
+                {{#each (limit item.tags maxTagsInBlock) as |tag tagIndex|}}
                     <a href="{{block.userOptions.uiUrl}}/search?status=active&tags={{tag.name}}" class="tag {{if (eq tag.tlp "red") "tlp-red"}}">
                         {{tag.name}}
                         <button class="delete-tag-btn" {{action "deleteTag" item tag.id index tagIndex}} disabled={{item.__deletingTag}}>
@@ -122,7 +139,7 @@
                 {{/if}}
 
                 <div class="edit-tags-btn-container">
-                    <span class="p-action" {{action "editTags" index}}>Add Tags {{fa-icon (if editTags "caret-down" "caret-up") fixedWidth=true}}</span>
+                    <span class="p-action" {{action "editTags" index}}>Add Tags {{fa-icon (if item.__editTags "caret-down" "caret-up") fixedWidth=true}}</span>
                 </div>
 
                 {{#if item.__editTags}}
@@ -145,17 +162,23 @@
                                     searchEnabled=true
                                     search=(action "searchTags")
                                     placeholder="Add Tag"
-                                    searchMessage="Loading Tags ..."
-                                    searchPlaceholder="Search tags"
+                                    searchMessage="Waiting to search"
+                                    searchPlaceholder="Enter a search term"
                                     closeOnSelect=true
                                     onopen=(action "searchTags" "" item)
                                     onChange=(action (mut item.__selectedTag)) as |tag|}}
                                 {{tag.name}}
                                 {{#if tag.isNew}}
+                                  <span>
                                     {{fa-icon "plus-circle" fixedWidth=true}}
+                                    {{bs-tooltip title="This is a new tag"}}
+                                  </span>
                                 {{/if}}
                                 {{#if tag.isPreferred}}
+                                  <span>
                                     {{fa-icon "check-circle" fixedWidth=true}}
+                                    {{bs-tooltip title="This is a preferred tag"}}
+                                  </span>
                                 {{/if}}
                             {{/power-select}}
 
@@ -164,8 +187,9 @@
                                     {{#if item.__addingTag}}
                                         {{fa-icon "spinner-third" spin=true fixedWidth=true}}
                                     {{else}}
-                                        {{fa-icon "plus" fixedWidth=true}}
+                                        {{fa-icon "plus" fixedWidth=true}}                                        
                                     {{/if}}
+                                    {{bs-tooltip title="Click to add tag"}}
                                 </button>
                             </div>
                         </div>


### PR DESCRIPTION
Fixes hash lookups on v5 server where `entity.type` is set to the specific hash type rather than the string "hash".  This is a workaround until server behavior is updated.

Also updated dependencies and added "subType" to the details template. Finally, worked on improving language around adding tags to make it more clear how to use it.